### PR TITLE
Allow key 0 on a select filter

### DIFF
--- a/Model/Behavior/FilteredBehavior.php
+++ b/Model/Behavior/FilteredBehavior.php
@@ -119,7 +119,7 @@ class FilteredBehavior extends ModelBehavior
 			return;
 		}
 
-		if (!isset($values[$configurationModelName][$configurationFieldName]) || empty($values[$configurationModelName][$configurationFieldName]))
+		if (!isset($values[$configurationModelName][$configurationFieldName]) || (empty($values[$configurationModelName][$configurationFieldName]) && $values[$configurationModelName][$configurationFieldName] != 0))
 		{
 			// no value to filter with, just skip this field
 			return;


### PR DESCRIPTION
The empty() php function returns true if the value is 0,
so this was preventing my boolean selects to filter using the key value 0

For example I have a 'is_active' column, and I want to set up a select filter with $options = array('0'=>'Inactive','1'=>'Active') but this line was not filtering by '0' because of the empty() function being true..
