### PR TITLE
Fixed Array to string conversion notice on line 327 of FilteredBehavior

### DIFF
--- a/Model/Behavior/FilteredBehavior.php
+++ b/Model/Behavior/FilteredBehavior.php
@@ -324,7 +324,7 @@ class FilteredBehavior extends ModelBehavior
 
 				break;
 			case 'select':
-				if (strlen(trim(strval($value))) == 0)
+				if ( is_string( $value ) && strlen(trim(strval($value))) == 0)
 				{
 					continue;
 				}


### PR DESCRIPTION
Using multiple select field caused a notice "Array to string conversion"
on line 327 of FilteredBehavior. Added check to ensure that the
parameter is a string before calling strlen.
