### PR TITLE
Fixes `join` with related models which have "prefixed" tables.

### DIFF
--- a/models/behaviors/filtered.php
+++ b/models/behaviors/filtered.php
@@ -177,7 +177,7 @@ class FilteredBehavior extends ModelBehavior
 
 					$query['joins'][] = array
 						(
-							'table' => $relatedModel->table,
+							'table' => $relatedModel->tablePrefix.$relatedModel->table,
 							'alias' => $relatedModelAlias,
 							'type' => 'INNER',
 							'conditions' => $conditions,


### PR DESCRIPTION
The filtering `join` for related models was not taking into consideration the case where the related model table is prefixed (using the `Model::$tablePrefix` property). 