### PR TITLE
Change PHP keywords to comply with PSR2

### DIFF
--- a/Test/Case/MockObjects.php
+++ b/Test/Case/MockObjects.php
@@ -98,7 +98,7 @@ class DocumentTestsController extends Controller
 
 	// must override this or the tests never complete..
 	// @TODO: mock partial?
-	public function redirect($url, $status = NULL, $exit = true)
+	public function redirect($url, $status = null, $exit = true)
 	{
 	}
 }


### PR DESCRIPTION
Hi, I've changed a PHP keyword to comply with [this standard](https://www.php-fig.org/psr/psr-2/#25-keywords-and-truefalsenull) in PSR2. It's admittedly a small fix but I hope it helps!